### PR TITLE
Log wrap

### DIFF
--- a/internal/components/logs/logs.go
+++ b/internal/components/logs/logs.go
@@ -89,6 +89,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		} else {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height - verticalMarginHeight
+			m.viewport.SetContent(wordwrap.String(m.contents, msg.Width))
 		}
 
 		if m.useHighPerformanceRenderer {

--- a/internal/components/logs/logs.go
+++ b/internal/components/logs/logs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/evertras/khan/internal/screens"
 	"github.com/evertras/khan/internal/styles"
+	"github.com/muesli/reflow/wordwrap"
 )
 
 type Model struct {
@@ -45,7 +46,7 @@ func (m Model) WithJobInfo(jobID, allocID, taskGroup, task string) Model {
 
 func (m Model) Append(data string) Model {
 	m.contents += data
-	m.viewport.SetContent(m.contents)
+	m.viewport.SetContent(wordwrap.String(m.contents, m.viewport.Width))
 
 	return m
 }
@@ -77,7 +78,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.viewport = viewport.New(msg.Width, msg.Height-verticalMarginHeight)
 			m.viewport.YPosition = headerHeight
 			m.viewport.HighPerformanceRendering = false
-			m.viewport.SetContent(m.contents)
+			m.viewport.SetContent(wordwrap.String(m.contents, msg.Width))
 			m.ready = true
 
 			// This is only necessary for high performance rendering, which in

--- a/test/long-lines.nomad
+++ b/test/long-lines.nomad
@@ -1,0 +1,16 @@
+job "long-lines" {
+  datacenters = ["dc1"]
+
+  type = "batch"
+
+  group "long-group" {
+    count = 1
+    task "long-task-is-long" {
+      driver = "docker"
+      config {
+        image = "alpine:latest"
+        args = ["echo", "Hello this is a really long and has a lot of stuff going on but it's a good thing we have wrapping in our logs or you would miss this very special offer buy now for just $9.99 for 99 months glhf it really is amazing how much text can fit onto a reasonably sized monitor hopefully this is actually going to wrap on your monitor if it doesn't that's pretty cool that you have such a ridiculously large monitor but most of us don't but still we really need to handle those edge cases and it would be pretty silly to ask you to make your terminal really thin just because you have an obnoxiously wide monitor that no mortal should wield"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #6 

Wrap log lines using `reflow`, which is recommended by the Bubble.